### PR TITLE
got rid of NavBar underline in styles.less

### DIFF
--- a/src/styles/NavBar.less
+++ b/src/styles/NavBar.less
@@ -4,4 +4,6 @@
         cursor: pointer;
     }
 
+
+
 }

--- a/src/styles/style.less
+++ b/src/styles/style.less
@@ -21,6 +21,24 @@ background-color: rgba(0,0,0,.1);
 border-radius: 20px;
 }
 
+// .ant-menu-horizontal > .ant-menu-item:hover, .ant-menu-horizontal > .ant-menu-submenu:hover 
+// {
+//    border-bottom: solid #1b242c 2px;
+
+// }
+
+.ant-menu-horizontal > .ant-menu-item-active, .ant-menu-horizontal > 
+.ant-menu-submenu-active, .ant-menu-horizontal > .ant-menu-item-open, 
+.ant-menu-item-selected, .ant-menu-horizontal > .ant-menu-submenu-selected .ant-menu-horizontal > .ant-menu-item, .ant-menu-horizontal > .ant-menu-submenu
+.ant-menu-horizontal > .ant-menu-item, .ant-menu-horizontal > .ant-menu-submenu,
+.ant-menu-horizontal > .ant-menu-item, .ant-menu-horizontal > .ant-menu-submenu 
+{
+    border-bottom: solid #1b242c 2px;
+
+}
+
+
+
 //Add all less files here and import this file into your components 
 
 //main files


### PR DESCRIPTION
Super ugly fix but it does the trick. If I try to comment out any of the ant design classes I grabbed it stops working. Commented out code gives the option to toggle the "active" properties on and off - we probably want to leave the active underline for now. 